### PR TITLE
net-scripts: check interfaces that are up against default route

### DIFF
--- a/bin/fpn0-down.sh
+++ b/bin/fpn0-down.sh
@@ -88,7 +88,18 @@ else
     [[ -n $VERBOSE ]] && echo "  FPN routing table not found!!"
 fi
 
-IPV4_INTERFACE=$(ip -o link show up | awk -F': ' '{print $2}' | grep -e 'usb' -e 'en' -e 'wl' -e 'lan' -e 'wan' -e 'eth' -e 'net' | head -n 1)
+DEFAULT_IFACE=$(ip route show default | awk '{print $5}')
+while read -r line; do
+    [[ -n $VERBOSE ]] && echo "Checking interfaces..."
+    IFACE=$(echo "$line")
+    if [[ $DEFAULT_IFACE = $IFACE ]]; then
+        IPV4_INTERFACE="${IFACE}"
+        [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
+        break
+    else
+        [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+    fi
+done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
 
 # set this to your "normal" network interface if needed
 #IPV4_INTERFACE="eth0"

--- a/bin/fpn0-setup.sh
+++ b/bin/fpn0-setup.sh
@@ -94,7 +94,18 @@ else
     zerotier-cli set "${ZT_NETWORK}" allowGlobal=1 > /dev/null 2>&1
 fi
 
-IPV4_INTERFACE=$(ip -o link show up | awk -F': ' '{print $2}' | grep -e 'usb' -e 'en' -e 'wl' -e 'lan' -e 'wan' -e 'eth' -e 'net' | head -n 1)
+DEFAULT_IFACE=$(ip route show default | awk '{print $5}')
+while read -r line; do
+    [[ -n $VERBOSE ]] && echo "Checking interfaces..."
+    IFACE=$(echo "$line")
+    if [[ $DEFAULT_IFACE = $IFACE ]]; then
+        IPV4_INTERFACE="${IFACE}"
+        [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
+        break
+    else
+        [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+    fi
+done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
 
 # set this to your "normal" network interface if needed
 #IPV4_INTERFACE="eth0"

--- a/bin/fpn1-setup.sh
+++ b/bin/fpn1-setup.sh
@@ -74,8 +74,20 @@ ZT_INTERFACE=$(zerotier-cli get "${ZT_SRC_NETID}" portDeviceName)
 ZT_SRC_ADDR=$(zerotier-cli get "${ZT_SRC_NETID}" ip4)
 
 # this should be the active interface with default route
-IPV4_INTERFACE=$(ip -o link show up | awk -F': ' '{print $2}' | grep -e 'usb' -e 'en' -e 'wl' -e 'lan' -e 'wan' -e 'eth' -e 'net' | head -n 1)
-INET_GATEWAY=$(ip route show | awk '/default / {print $3}')
+DEFAULT_IFACE=$(ip route show default | awk '{print $5}')
+while read -r line; do
+    [[ -n $VERBOSE ]] && echo "Checking interfaces..."
+    IFACE=$(echo "$line")
+    if [[ $DEFAULT_IFACE = $IFACE ]]; then
+        IPV4_INTERFACE="${IFACE}"
+        [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
+        break
+    else
+        [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+    fi
+done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
+
+INET_GATEWAY=$(ip route show default | awk '{print $3}')
 
 if [[ -n $ETH0_NULL ]]; then
     IPV4_INTERFACE="${ETH0_NULL}"


### PR DESCRIPTION
Fix net scripts for multiple interfaces in the UP state and pick the default route device.