### PR TITLE
Distro fixes for multiple default routes and network interface names

### DIFF
--- a/README_0.9.0-release-notes_DRAFT.rst
+++ b/README_0.9.0-release-notes_DRAFT.rst
@@ -73,7 +73,6 @@ The required network ports for FreePN user node daemon include:
 .. _github: https://github.com/freepn
 .. _fpnd: https://github.com/freepn/fpnd
 .. _freepn-gtk3-tray: https://github.com/freepn/freepn-gtk3-tray
-.. _PPA on Launchpad: https://launchpad.net/~nerdboy/+archive/ubuntu/embedded
 
 
 2.0 - Referenced Documents
@@ -120,6 +119,7 @@ For other distributions:
   + use the latest `fpnd source release on github`_
 
 
+.. _PPA on Launchpad: https://launchpad.net/~nerdboy/+archive/ubuntu/embedded
 .. _python-overlay: https://github.com/freepn/python-overlay
 .. _fpnd source release on github: https://github.com/freepn/fpnd/releases
 
@@ -340,9 +340,8 @@ included ``.rst`` documents.
 .. note:: You can build a (complete) PDF version of this document using the
           ``rst2pdf`` tool.  After cloning this repository, cd into the top
           level directory and run the following command::
-          
+
             $ rst2pdf -o README_0.9.0-release-notes_DRAFT.pdf
 
 
 .. include:: changelog.rst
-

--- a/bin/fpn0-down.sh
+++ b/bin/fpn0-down.sh
@@ -18,7 +18,9 @@ exec &> >(tee -ia /tmp/fpn0-down-${DATE}_output.log)
 exec 2> >(tee -ia /tmp/fpn0-down-${DATE}_error.log)
 
 #VERBOSE="anything"
-#DROP_DNS_53="anything"
+#DROP_DNS_53="anything"  <= fpnd.ini
+# set the preferred network interface if needed
+#SET_IPV4_IFACE="eth0"  <= fpnd.ini
 
 # set allowed ports (still TBD))
 ports_to_fwd="http https domain submission imaps ircs ircs-u"
@@ -92,23 +94,39 @@ else
     [[ -n $VERBOSE ]] && echo "  FPN routing table not found!!"
 fi
 
-DEFAULT_IFACE=$(ip route show default | awk '{print $5}')
-while read -r line; do
-    [[ -n $VERBOSE ]] && echo "Checking interfaces..."
-    IFACE=$(echo "$line")
-    if [[ $DEFAULT_IFACE = $IFACE ]]; then
-        IPV4_INTERFACE="${IFACE}"
-        [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
-        break
+if [[ -n $SET_IPV4_IFACE ]]; then
+    [[ -n $VERBOSE ]] && echo "Looking for $SET_IPV4_IFACE"
+    TEST_IFACE=$(ip route show default | { grep -o "${SET_IPV4_IFACE}" || test $? = 1; })
+    if [[ -n $TEST_IFACE ]]; then
+        [[ -n $VERBOSE ]] && echo "  $TEST_IFACE looks good..."
+        IPV4_INTERFACE="${TEST_IFACE}"
     else
-        [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+        [[ -n $VERBOSE ]] && echo "  $TEST_IFACE not found!"
+        DEFAULT_IFACE=$(ip route show default | awk '{print $5}' | head -n 1)
     fi
-done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
+else
+    DEFAULT_IFACE=$(ip route show default | awk '{print $5}' | head -n 1)
+fi
 
-# set this to your "normal" network interface if needed
-#IPV4_INTERFACE="eth0"
-#IPV4_INTERFACE="wlan0"
-#[[ -n $IPV4_INTERFACE ]] || IPV4_INTERFACE="mlan0"
+if ! [[ -n $IPV4_INTERFACE ]]; then
+    while read -r line; do
+        [[ -n $VERBOSE ]] && echo "Checking interfaces..."
+        IFACE=$(echo "$line")
+        if [[ $DEFAULT_IFACE = $IFACE ]]; then
+            IPV4_INTERFACE="${IFACE}"
+            [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
+            break
+        else
+            [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+        fi
+    done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
+fi
+
+if ! [[ -n $IPV4_INTERFACE ]]; then
+    echo "No usable network interface found! (check settings?)"
+    exit 1
+fi
+
 INET_ADDRESS=$(ip address show "${IPV4_INTERFACE}" | awk '/inet / {print $2}' | cut -d/ -f1)
 
 if [[ -n $VERBOSE ]]; then

--- a/bin/fpn1-down.sh
+++ b/bin/fpn1-down.sh
@@ -20,6 +20,8 @@ exec 2> >(tee -ia /tmp/fpn1-down-${DATE}_error.log)
 
 # uncomment for more output
 #VERBOSE="anything"
+# set the preferred network interface if needed
+#SET_IPV4_IFACE="eth0"  <= fpnd.ini
 
 # set allowed ports (still TBD))
 ports_to_fwd="http https domain submission imaps ircs ircs-u"
@@ -69,25 +71,40 @@ if [[ -n $ZT_SRC_NETID ]]; then
     ZT_SRC_ADDR=$(zerotier-cli get "${ZT_SRC_NETID}" ip4)
 fi
 
-# this should be the active interface with default route
-DEFAULT_IFACE=$(ip route show default | awk '{print $5}')
-while read -r line; do
-    [[ -n $VERBOSE ]] && echo "Checking interfaces..."
-    IFACE=$(echo "$line")
-    if [[ $DEFAULT_IFACE = $IFACE ]]; then
-        IPV4_INTERFACE="${IFACE}"
-        [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
-        break
+if [[ -n $SET_IPV4_IFACE ]]; then
+    [[ -n $VERBOSE ]] && echo "Looking for $SET_IPV4_IFACE"
+    TEST_IFACE=$(ip route show default | { grep -o "${SET_IPV4_IFACE}" || test $? = 1; })
+    if [[ -n $TEST_IFACE ]]; then
+        [[ -n $VERBOSE ]] && echo "  $TEST_IFACE looks good..."
+        IPV4_INTERFACE="${TEST_IFACE}"
     else
-        [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+        [[ -n $VERBOSE ]] && echo "  $TEST_IFACE not found!"
+        DEFAULT_IFACE=$(ip route show default | awk '{print $5}' | head -n 1)
     fi
-done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
-
-INET_GATEWAY=$(ip route show default | grep src | awk '{print $3}')
-
-if [[ -n $ETH0_NULL ]]; then
-    IPV4_INTERFACE="${ETH0_NULL}"
+else
+    DEFAULT_IFACE=$(ip route show default | awk '{print $5}' | head -n 1)
 fi
+
+if ! [[ -n $IPV4_INTERFACE ]]; then
+    while read -r line; do
+        [[ -n $VERBOSE ]] && echo "Checking interfaces..."
+        IFACE=$(echo "$line")
+        if [[ $DEFAULT_IFACE = $IFACE ]]; then
+            IPV4_INTERFACE="${IFACE}"
+            [[ -n $VERBOSE ]] && echo "  Found interface $IFACE"
+            break
+        else
+            [[ -n $VERBOSE ]] && echo "  Skipping $IFACE"
+        fi
+    done < <(ip -o link show up  | awk -F': ' '{print $2}' | grep -v lo)
+fi
+
+if ! [[ -n $IPV4_INTERFACE ]]; then
+    echo "No usable network interface found! (check settings?)"
+    exit 1
+fi
+
+INET_GATEWAY=$(ip route show default | grep $IPV4_INTERFACE | awk '{print $3}')
 
 INET_ADDRESS=$(ip address show "${IPV4_INTERFACE}" | awk '/inet / {print $2}' | cut -d/ -f1)
 ZT_SRC_NET=$(ip route show | grep ${ZT_INTERFACE} | grep -v '169.254' | awk '{print $1}')

--- a/bin/ping_github.sh
+++ b/bin/ping_github.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+# ping_google.sh
+# ping the google dns
+
+failures=0
+trap 'failures=$((failures+1))' ERR
+
+IFACE=${1:-eth0}
+TIMEOUT=${2:-1}
+
+/bin/ping -c1 -w$TIMEOUT -I$IFACE github.com > /dev/null 2>&1
+
+if ((failures == 0)); then
+        echo "Success"
+else
+	echo "Failure"
+	exit 1
+fi

--- a/bin/show-geoip.sh
+++ b/bin/show-geoip.sh
@@ -57,7 +57,7 @@ CURL_BASE=$(semver_to_int "${CURL_BASEVER}")
 
 /usr/bin/wget $wget_args -o $log_file -O - -q https://geoip.ubuntu.com/lookup > $xml_file
 
-if [[ -s $xml_file ]]; then
+if ! [[ -s $xml_file ]]; then
     /usr/bin/wget $wget_args -o $log_file -O - -q https://geoip.ubuntu.com/lookup > $xml_file
 fi
 

--- a/bin/show-geoip.sh
+++ b/bin/show-geoip.sh
@@ -20,7 +20,7 @@ RUN_DIR="/run/fpnd"
 xml_file="${TEMP_DIR}/geoip-location.xml"
 log_file="${TEMP_DIR}/wget.log"
 clog_file="${TEMP_DIR}/curl.log"
-wget_args="--timeout=1 --waitretry=0 --tries=5 --retry-connrefused"
+wget_args="--timeout=2 --waitretry=0 --tries=5 --retry-connrefused"
 
 TMP_FILES="${xml_file} ${log_file} ${clog_file}"
 for tempfile in "${TMP_FILES}"; do
@@ -57,6 +57,9 @@ CURL_BASE=$(semver_to_int "${CURL_BASEVER}")
 
 /usr/bin/wget $wget_args -o $log_file -O - -q https://geoip.ubuntu.com/lookup > $xml_file
 
+if [[ -s $xml_file ]]; then
+    /usr/bin/wget $wget_args -o $log_file -O - -q https://geoip.ubuntu.com/lookup > $xml_file
+fi
 
 IP_ADDR=$(cat $xml_file | sed -n -e 's/.*<Ip>\(.*\)<\/Ip>.*/\1/p')
 LAT_FULL=$(cat $xml_file | sed -n -e 's/.*<Latitude>\(.*\)<\/Latitude>.*/\1/p')

--- a/etc/fpnd.ini
+++ b/etc/fpnd.ini
@@ -7,6 +7,7 @@ prefix = None
 user_perms = False
 log_name = fpnd.log
 pid_name = fpnd.pid
+default_iface = None
 doh_host = doh.eastus.pi-dns.com
 private_dns_only = False
 

--- a/etc/fpnd.ini
+++ b/etc/fpnd.ini
@@ -8,7 +8,7 @@ user_perms = False
 log_name = fpnd.log
 pid_name = fpnd.pid
 default_iface = None
-doh_host = doh.eastus.pi-dns.com
+doh_host = None
 private_dns_only = False
 
 [Paths]

--- a/node_tools/helper_funcs.py
+++ b/node_tools/helper_funcs.py
@@ -25,6 +25,7 @@ ENODATA = Constant('ENODATA')  # error return for async state data updates
 
 NODE_SETTINGS = {
     u'private_dns_only': False,  # drop routed port 53 traffic
+    u'default_iface': None,  # set default network interface name
     u'doh_host': None,  # use doh_host for show_geoip command
     u'max_cache_age': 60,  # maximum cache age in seconds
     u'use_localhost': False,  # messaging interface to use
@@ -80,6 +81,7 @@ def do_setup():
         debug = my_conf.getboolean('Options', 'debug')
         user_perms = my_conf.getboolean('Options', 'user_perms')
         curl_doh_host = my_conf['Options']['doh_host']
+        default_iface_name = my_conf['Options']['default_iface']
         private_dns = my_conf.getboolean('Options', 'private_dns_only')
         home = my_conf['Paths']['home_dir']
         NODE_SETTINGS['mode'] = mode
@@ -87,6 +89,7 @@ def do_setup():
         NODE_SETTINGS['runas_user'] = user_perms
         NODE_SETTINGS['home_dir'] = home
         NODE_SETTINGS['doh_host'] = curl_doh_host
+        NODE_SETTINGS['default_iface'] = default_iface_name
         NODE_SETTINGS['private_dns_only'] = private_dns
         if 'system' not in msg:
             prefix = my_conf['Options']['prefix']

--- a/node_tools/network_funcs.py
+++ b/node_tools/network_funcs.py
@@ -25,7 +25,7 @@ def do_host_check(path=None):
 
     if not path:
         path = NODE_SETTINGS['home_dir']
-    cmd = os.path.join(path, 'ping_google.sh')
+    cmd = os.path.join(path, 'ping_github.sh')
 
     result = do_net_cmd([cmd])
     return result

--- a/node_tools/network_funcs.py
+++ b/node_tools/network_funcs.py
@@ -294,10 +294,13 @@ def do_net_cmd(cmd):
         logger.error('Bad cmd or path: {}'.format(cmd[0]))
 
     env_dict = {'VERBOSE': '',
-                'DROP_DNS_53': ''}
+                'DROP_DNS_53': '',
+                'SET_IPV4_IFACE': ''}
 
     if NODE_SETTINGS['private_dns_only']:
         env_dict['DROP_DNS_53'] = 'yes'
+    if NODE_SETTINGS['default_iface'] is not None:
+        env_dict['SET_IPV4_IFACE'] = NODE_SETTINGS['default_iface']
     logger.debug('ENV: net script settings are {}'.format(env_dict.items()))
 
     # with shell=false cmd must be a sequence not a string

--- a/test/test_data/settings.ini
+++ b/test/test_data/settings.ini
@@ -7,8 +7,8 @@ prefix = fpn_
 user_perms = True
 log_name = daemon.log
 pid_name = daemon.pid
-doh_host = doh.eastus.pi-dns.com
-local_stub_resolver = False
+default_iface = None
+doh_host = None
 private_dns_only = False
 
 [Paths]


### PR DESCRIPTION
Add config option for setting the primary network interface name when there's more than one active interface with a default route.  If set, we check for the interface name and fall back to default behavior if not found (where "default behavior" is picking the interface from the default route, and picking the better route metric if more than one default route is found).