### PR TITLE
dns routing config options (default off)

### DIFF
--- a/README_DNS_privacy.rst
+++ b/README_DNS_privacy.rst
@@ -28,6 +28,7 @@ Terms and Acronyms
 :DNSCrypt: This can mean the protocol or an implementation (eg, DNSCrypt-proxy)
 :DNS over TLS: DoT is the primary encrypted DNS implementation (TCP over port 853)
 :DNS over HTTPS: DoH is an alternate method using the standard (secure) web port
+:PII: Personally Identifiable Information (anything that ties data to an individual)
 :stub resolver: a local non-recursive DNS "server" that uses DoT and/or DoH
 
 
@@ -48,9 +49,10 @@ internet.  These not-so-nice entities may include the following:
 DNS handling in FreePN
 =======================
 
-There are two DNS modes for the fpnd network daemon:
+There are three DNS modes for the fpnd network daemon:
 
-* route your "normal" DNS requests with your web traffic (the default)
+* leave your DNS traffic as-is (the default)
+* route your "normal" DNS requests with your web traffic (optional)
 * drop all insecure outgoing DNS draffic if you are using a local
   secure stub resolver (optional)
 
@@ -60,6 +62,20 @@ Reasons why the first option is the default:
 * breaking DNS is a *bad* thing
 * too many other packages you probably have installed already do this
   (mainly systemd and networkmanager)
+
+The first option above involves doing nothing about your current DNS
+setup, ie, it will work just as it always has, but leaves it insecure
+and definitely not private.
+
+The second option involves using a public DNS provider (eg, Google or
+Cloudflare) and setting ``route_dns`` to True in the fpnd settings file
+(fpnd.ini).  If you're on Ubuntu (or Gentoo with a systemd profile) then
+systemd should already be the default "manager" of DNS settings, which
+makes it trivial to add our example config and edit it to suit your needs.
+
+The third option (which we also have an example config fragment for)
+involves installing a secure DNS stub resolver on your device (such as
+stubby; see below) and configuring systemd-resolved to use it.
 
 So, *if* you want to take back a big chunk of your privacy and you're
 using FreePN because you want more privacy, then you really should

--- a/etc/fpnd.ini
+++ b/etc/fpnd.ini
@@ -9,6 +9,7 @@ log_name = fpnd.log
 pid_name = fpnd.pid
 default_iface = None
 doh_host = None
+route_dns = False
 private_dns_only = False
 
 [Paths]

--- a/etc/fpnd.resolved
+++ b/etc/fpnd.resolved
@@ -1,0 +1,3 @@
+[Resolve]
+Cache=yes
+DNS=1.1.1.1 8.8.8.8

--- a/node_tools/helper_funcs.py
+++ b/node_tools/helper_funcs.py
@@ -25,6 +25,7 @@ ENODATA = Constant('ENODATA')  # error return for async state data updates
 
 NODE_SETTINGS = {
     u'private_dns_only': False,  # drop routed port 53 traffic
+    u'route_dns': False,  # route insecure dns with web traffic
     u'default_iface': None,  # set default network interface name
     u'doh_host': None,  # use doh_host for show_geoip command
     u'max_cache_age': 60,  # maximum cache age in seconds
@@ -76,21 +77,19 @@ def do_setup():
     dirs = AppDirs('fpnd', 'FreePN')
     my_conf, msg = config_from_ini()
     if my_conf:
+        home = my_conf['Paths']['home_dir']
         role = my_conf['Options']['role']
         mode = my_conf['Options']['mode']
         debug = my_conf.getboolean('Options', 'debug')
         user_perms = my_conf.getboolean('Options', 'user_perms')
-        curl_doh_host = my_conf['Options']['doh_host']
-        default_iface_name = my_conf['Options']['default_iface']
-        private_dns = my_conf.getboolean('Options', 'private_dns_only')
-        home = my_conf['Paths']['home_dir']
+        NODE_SETTINGS['doh_host'] = my_conf['Options']['doh_host']
+        NODE_SETTINGS['default_iface'] = my_conf['Options']['default_iface']
+        NODE_SETTINGS['route_dns_53'] = my_conf.getboolean('Options', 'route_dns')
+        NODE_SETTINGS['private_dns_only'] = my_conf.getboolean('Options', 'private_dns_only')
         NODE_SETTINGS['mode'] = mode
         NODE_SETTINGS['debug'] = debug
         NODE_SETTINGS['runas_user'] = user_perms
         NODE_SETTINGS['home_dir'] = home
-        NODE_SETTINGS['doh_host'] = curl_doh_host
-        NODE_SETTINGS['default_iface'] = default_iface_name
-        NODE_SETTINGS['private_dns_only'] = private_dns
         if 'system' not in msg:
             prefix = my_conf['Options']['prefix']
         else:

--- a/node_tools/network_funcs.py
+++ b/node_tools/network_funcs.py
@@ -25,7 +25,7 @@ def do_host_check(path=None):
 
     if not path:
         path = NODE_SETTINGS['home_dir']
-    cmd = os.path.join(path, 'ping_github.sh')
+    cmd = os.path.join(path, 'ping_google.sh')
 
     result = do_net_cmd([cmd])
     return result
@@ -295,8 +295,11 @@ def do_net_cmd(cmd):
 
     env_dict = {'VERBOSE': '',
                 'DROP_DNS_53': '',
+                'ROUTE_DNS_53': '',
                 'SET_IPV4_IFACE': ''}
 
+    if NODE_SETTINGS['route_dns_53']:
+        env_dict['ROUTE_DNS_53'] = 'yes'
     if NODE_SETTINGS['private_dns_only']:
         env_dict['DROP_DNS_53'] = 'yes'
     if NODE_SETTINGS['default_iface'] is not None:

--- a/test/test_data/settings.ini
+++ b/test/test_data/settings.ini
@@ -9,6 +9,7 @@ log_name = daemon.log
 pid_name = daemon.pid
 default_iface = None
 doh_host = None
+route_dns = False
 private_dns_only = False
 
 [Paths]

--- a/test/test_sched_decorators.py
+++ b/test/test_sched_decorators.py
@@ -13,6 +13,7 @@ import pytest
 import schedule
 from schedule import every
 
+from node_tools.helper_funcs import NODE_SETTINGS
 from node_tools.helper_funcs import AttrDict
 from node_tools.helper_funcs import send_announce_msg
 from node_tools.network_funcs import echo_client
@@ -122,6 +123,9 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual(len(schedule.jobs), 0)
 
     def test_run_net_cmd_sdown(self):
+        NODE_SETTINGS['route_dns_53'] = True
+        NODE_SETTINGS['private_dns_only'] = True
+
         cmd_down0 = get_net_cmds(self.bin_dir, 'fpn0', False)
         cmd_down1 = get_net_cmds(self.bin_dir, 'fpn1', False)
 


### PR DESCRIPTION
* add settings option to route plain-text dns, default off
* wire config options so private_dns_only overrides the route_dns option
* add drop-in config for systemd-resolvd to use external dns while preserving local interface config
