### PR TITLE
extend net change timeout for high latency/bad connections

### DIFF
--- a/README_0.9.0-release-notes_DRAFT.rst
+++ b/README_0.9.0-release-notes_DRAFT.rst
@@ -46,6 +46,7 @@ more granular user controls.
 
 .. _FreePN: https://github.com/freepn
 
+
 1.2 - Required / Optional Software
 ----------------------------------
 
@@ -88,6 +89,7 @@ The required outgoing network ports for FreePN user node daemon include:
 2.0 - Referenced Documents
 ==========================
 
+* ZeroTier Manual - https://www.zerotier.com/manual/
 * DI-IPSC-81442 - Software Version Description (SVD) Data Item Description (DID)
 
 
@@ -100,8 +102,8 @@ A supported linux distribution, mainly something that uses `.ebuilds`
 (eg, Gentoo or funtoo) or a supported Ubuntu series, currently bionic
 18.0.4 LTS, or focal 20.0.4 LTS (see the above`PPA on Launchpad`_).
 Note you can also use the focal PPA series on the latest kali images,
-however, the the fpnd.service is broken agoinst the latest systemd
-upgrade to 264 or higher (and there is no fix yet).
+however, the fpnd.service is broken against the latest systemd upgrade
+to 264 or higher (and there is no fix yet).
 
 3.1 - Packages and Source Code
 ------------------------------

--- a/node_tools/network_funcs.py
+++ b/node_tools/network_funcs.py
@@ -59,7 +59,7 @@ def do_net_check(path=None):
         if fpn_data['fpn0'] and fpn_data['fpn1'] and retcode == 4:
             if fpn_data['route'] is True:
                 fpn_data['route'] = None
-                net_wait.set('failed_once', True, 45)
+                net_wait.set('failed_once', True, 65)
             else:
                 if host_state:
                     fpn_data['route'] = False


### PR DESCRIPTION
Allow more time to account for slow/bad or high latency connections and (hopefully) avoid spurious reconnects.