### PR TITLE
route domain-s port, fix dnsmasq.conf, doc updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Docs for FreePN tools
 * `Old README`_ - previous (template-based) FOSS readme
 
 
-.. _Release Notes: README_0.9.0-release-notes.rst
+.. _Release Notes: README_0.9.1-release-notes.rst
 .. _Change Log: changelog.rst
 .. _DNS Privacy: README_DNS_privacy.rst
 .. _DNS Setup: README_DNS_setup.rst

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,16 @@ to be trusted hosts (as they belong to the user).
 .. _XDG-compliant desktop: https://freedesktop.org/wiki/
 
 
+Prototype design limitations
+----------------------------
+
+* we only route www (http and https) and dns (optional) traffic
+* traffic routing supports IPv4 only (no IPv6)
+* DNS privacy depends entirely on *your* DNS config
+* the most common local-only DNS config *is not* routable out-of-the-box
+* it takes *you* to make the changes to stop DNS privacy leaks
+
+
 Docs for FreePN tools
 =====================
 
@@ -184,9 +194,9 @@ DNS settings:
 
 * **route_dns**: Default is ``False``; only set to ``True`` if you've configured
   your global (plain-text) DNS settings to use an external/public DNS server, eg
-  Cloudflare_
+  Cloudflare_ (or you already have secure DNS in place)
 * **private_dns_only**: Default is ``False``; only set to ``True`` when you're
-  alreafy running a `secure local DNS resolver`_, eg stubby_
+  already running a `secure local DNS resolver`_, eg stubby_
 
 Misc settings:
 

--- a/README_0.9.1-release-notes.rst
+++ b/README_0.9.1-release-notes.rst
@@ -2,7 +2,7 @@
  Software Version Description for fpnd |Version|
 =================================================
 
-.. |Version| replace:: 0.9.0
+.. |Version| replace:: 0.9.1
 
 :date: |date|, |time| PST8PDT
 :author: Stephen L Arnold

--- a/README_DNS_privacy.rst
+++ b/README_DNS_privacy.rst
@@ -1,12 +1,13 @@
 What is DNS anyway?
 ===================
 
-A DNS (Domain Name Server) is a computer/device used to translate between
-(human-readable) hostnames and their corresponding IP addresses (thus,
-without one you would have to know *in advance* the IP address of every
-machine you connect to).  Each time you type a name into your browser or
-click a link, that action triggers a DNS lookup using your local settings
-for DNS nameservers.
+DNS (Domain Name System) is a framework for translating between names and
+IP addresses, and a ``nameserver`` is a computer/device that uses DNS to
+translate between (human-readable) hostnames and their corresponding IP
+addresses (thus, without one you would have to know *in advance* the IP
+address of every machine you connect to).  Each time you type a name into
+your browser or click a link, that action triggers a DNS lookup using your
+local settings for DNS nameservers.
 
 Inherent problems with the legacy DNS infrastructure include:
 
@@ -14,7 +15,6 @@ Inherent problems with the legacy DNS infrastructure include:
   hijacking, etc
 * even though it supports TCP, it relies largely on UDP, which leaves
   it open to even more attack methods
-
 
 DNS in its legacy form has been around as long as the Internet, but now
 we have both Internet RFCs for encrypted DNS, and a growing population

--- a/README_DNS_setup.rst
+++ b/README_DNS_setup.rst
@@ -296,7 +296,10 @@ then check your new config::
                         16.172.in-addr.arpa
   (more output suppressed)
 
-and try to resolve something::
+and make sure your new nameserver address appears in the Global section
+as shown above (note your output may look slightly different).
+
+Finally, try to resolve something::
 
   $ dig www.gentoo.org
 

--- a/bin/fpn0-setup.sh
+++ b/bin/fpn0-setup.sh
@@ -160,8 +160,9 @@ $IPTABLES -t mangle -A OUTPUT -j fpn0-mangleout
 $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p tcp --dport 443 -j MARK --set-mark 1
 $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p tcp --dport 80 -j MARK --set-mark 1
 if [[ -n $ROUTE_DNS_53 ]] && ! [[ -n $DROP_DNS_53 ]]; then
-    $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p udp --dport 53 -j MARK --set-mark 1
     $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p tcp --dport 53 -j MARK --set-mark 1
+    $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p udp --dport 53 -j MARK --set-mark 1
+    $IPTABLES -t mangle -A fpn0-mangleout -o ${IPV4_INTERFACE} -p tcp --dport 853 -j MARK --set-mark 1
 fi
 
 # nat/postrouting chain
@@ -173,6 +174,7 @@ $IPTABLES -t nat -A fpn0-postnat -s ${INET_ADDRESS} -o ${ZT_INTERFACE} -p tcp --
 if [[ -n $ROUTE_DNS_53 ]] && ! [[ -n $DROP_DNS_53 ]]; then
     $IPTABLES -t nat -A fpn0-postnat -s ${INET_ADDRESS} -o ${ZT_INTERFACE} -p tcp --dport 53 -j SNAT --to ${ZT_ADDRESS}
     $IPTABLES -t nat -A fpn0-postnat -s ${INET_ADDRESS} -o ${ZT_INTERFACE} -p udp --dport 53 -j SNAT --to ${ZT_ADDRESS}
+    $IPTABLES -t nat -A fpn0-postnat -s ${INET_ADDRESS} -o ${ZT_INTERFACE} -p tcp --dport 853 -j SNAT --to ${ZT_ADDRESS}
 fi
 
 if [[ -n $DROP_DNS_53 ]]; then

--- a/bin/fpn1-setup.sh
+++ b/bin/fpn1-setup.sh
@@ -146,6 +146,8 @@ $IPTABLES -A fpn1-forward -i "${IPV4_INTERFACE}" -o "${ZT_INTERFACE}" -d "${ZT_S
 $IPTABLES -A fpn1-forward -i "${IPV4_INTERFACE}" -o "${ZT_INTERFACE}" -d "${ZT_SRC_NET}" -p tcp --sport 443 -j ACCEPT
 $IPTABLES -A fpn1-forward -i "${ZT_INTERFACE}" -o "${IPV4_INTERFACE}" -s "${ZT_SRC_NET}" -p tcp --dport 53 -j ACCEPT
 $IPTABLES -A fpn1-forward -i "${IPV4_INTERFACE}" -o "${ZT_INTERFACE}" -d "${ZT_SRC_NET}" -p tcp --sport 53 -j ACCEPT
+$IPTABLES -A fpn1-forward -i "${ZT_INTERFACE}" -o "${IPV4_INTERFACE}" -s "${ZT_SRC_NET}" -p tcp --dport 853 -j ACCEPT
+$IPTABLES -A fpn1-forward -i "${IPV4_INTERFACE}" -o "${ZT_INTERFACE}" -d "${ZT_SRC_NET}" -p tcp --sport 853 -j ACCEPT
 
 [[ -n $VERBOSE ]] && echo ""
 if ((failures < 1)); then

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,16 @@
+0.9.1 (2020-09-24)
+-----------------
+- Add domain-s port to optional routing, fix dnsmasq.conf, doc updates. [Stephen Arnold]
+- Merge pull request #74 from freepn/leak-patch. [Steve Arnold]
+
+  * Remove deprecated parameter from run_until_success decorator.
+  * Add a new README_examples.rst doc, plus more doc updates.
+  * Test/test_mock_api_get.py: fix silly N rules test.
+  * Fix route check so it doesn't leak before the routes are configured.
+  * examples: add dnsmasq cfg, update stubby resolver list
+  * fix rules (allow encrypted DNS), update doc
+
+
 0.9.0 (2020-09-22)
 ------------------
 - Bump version for alpha release and update changelog. [Stephen Arnold]

--- a/etc/dnsmasq.conf
+++ b/etc/dnsmasq.conf
@@ -2,12 +2,22 @@
 # we use dnsmasq to proxy for stubby and listen on port 53
 proxy-dnssec
 no-resolv
+no-poll
 server=127.0.0.1#5453
 
 listen-address=127.0.0.1
 no-dhcp-interface=127.0.0.1
 
+## This assumes you have a local DNS server (eg, dnsmasq) configured
+## to resolve hosts on your local (private) LAN and it listens on
+## <local_DNS_IP>, eg, something like 192.168.1.1
+## This config enables both local FQDN and short hostname resolution
+
 # add your local domain and dns server here (replace domain and IP addr)
-server=/<your_domain.local>/192.168.1.1
-domain-needed
+local=/<your_domain.local>/<local_DNS_IP>
+# this will forward short hostnames to the same local DNS server
+local=//<local_DNS_IP>
+
+# this disables forwarding short hostnames; uncomment if you only use FQDN
+#domain-needed
 bogus-priv

--- a/etc/stubby.yml
+++ b/etc/stubby.yml
@@ -1,7 +1,7 @@
-# note this is only the pi-dns US upstream server list for now (this is only
+# note this is only an alternate upstream server list for now (this is only
 # a fragment, not a complete config)
 
-upstream_recursive_servers:
+# also note this goes under the section named upstream_recursive_servers:
 # see https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/public-resolvers.md
 # https://pi-dns.com/
   - address_data: 2a04:bdc7:100:70::abcd


### PR DESCRIPTION
* add back port 853 to route_dns confg option
* fix example `dnsmasq.conf` for local short names
* complete the three example scenarios for the example configs