### PR TITLE
fix: use max_timeout to wait before setting route to False

### DIFF
--- a/bin/show-geoip.sh
+++ b/bin/show-geoip.sh
@@ -49,7 +49,7 @@ semver_to_int() {
     #if [[ -n $DOH_HOST ]]; then
         #doh_arg="--doh-url https://${DOH_HOST}/dns-query"
         #if [[ -n $VERBOSE ]]; then
-            #echo "Using curl doh_arg valus: $doh_arg"
+            #echo "Using curl doh_arg values: $doh_arg"
         #fi
     #fi
     #/usr/bin/curl --stderr $clog_file --silent -m 3 $doh_arg https://geoip.ubuntu.com/lookup > $xml_file

--- a/node_tools/helper_funcs.py
+++ b/node_tools/helper_funcs.py
@@ -369,12 +369,14 @@ def put_state_msg(msg, state_file=None, clean=True):
 def reset_wedge_state():
     """
     Reset route and wdg_ref to defaults whenever 'fpn0' state changes
-    to UP.
+    to UP and set a post-up wait_cache so we don't send a wedge msg
+    too soon.
     """
     from node_tools import state_data as st
 
     st.fpnState['wdg_ref'] = None
     st.fpnState['route'] = None
+    st.wait_cache.set('fpn0_UP', True, NODE_SETTINGS['max_timeout'])
 
 
 def run_event_handlers(diff=None):

--- a/node_tools/network_funcs.py
+++ b/node_tools/network_funcs.py
@@ -57,7 +57,9 @@ def do_net_check(path=None):
 
     if not state:
         host_state, _, _ = do_host_check()
-        if fpn_data['fpn0'] and fpn_data['fpn1'] and retcode == 4:
+        if net_wait.get('fpn0_UP'):
+            fpn_data['route'] = None
+        elif fpn_data['fpn0'] and fpn_data['fpn1'] and retcode == 4:
             if fpn_data['route'] is True:
                 fpn_data['route'] = None
                 net_wait.set('failed_once', True, max_wait)
@@ -78,8 +80,8 @@ def do_net_check(path=None):
                 fpn_data['wdg_ref'] = None
                 put_state_msg('CONNECTED')
             logger.info('HEALTH: network route state is {}'.format(fpn_data['route']))
-        elif fpn_data['route'] is None:
-            logger.info('HEALTH: no state yet (state is {})'.format(fpn_data['route']))
+    if fpn_data['route'] is None:
+        logger.info('HEALTH: no state yet (state is {})'.format(fpn_data['route']))
 
     return result
 

--- a/test/test_node_msgs.py
+++ b/test/test_node_msgs.py
@@ -122,11 +122,11 @@ class BaseTestCase(unittest.TestCase):
         self.service.subscribe('offline', offline)
 
     def tearDown(self):
+        self.service.socket.close()
         self.node_q.clear()
         self.off_q.clear()
         self.pub_q.clear()
         self.tmp_q.clear()
-        self.service.socket.close()
 
 
 class TestPubCfg(BaseTestCase):

--- a/test/test_node_tools.py
+++ b/test/test_node_tools.py
@@ -353,7 +353,10 @@ class NetPeerCheckTest(unittest.TestCase):
     problematic...
     """
     def setUp(self):
+        from node_tools import state_data as st
+
         super(NetPeerCheckTest, self).setUp()
+        st.wait_cache.set('fpn0_UP', True, 1)
         NODE_SETTINGS['home_dir'] = os.path.join(os.getcwd(), 'bin')
 
     @pytest.mark.xfail(strict=False)


### PR DESCRIPTION
* add wait_cache using max_timeout to fpn0 UP handler
* make route check wait for max_timeout before setting route false

Fixes issue #89  (de-wedging nodes who never route) and makes us a little more tolerant of transient lookup errors (since route check relies on dns/https lookups over fpn0 tunnel).
